### PR TITLE
Fix category menu item selection and scrolling logic

### DIFF
--- a/app/components/view-table/categoryMenu.tsx
+++ b/app/components/view-table/categoryMenu.tsx
@@ -53,11 +53,11 @@ const CategoryMenu = ({ items, onClickMenu }: CategoryMenuProps) => {
         }
     }, [onClickMenu, scrollToItem]);
 
-    const onClickItemBtn = useCallback((key: React.Key, childKey?: React.Key, index?: number | undefined) => {
+    const onClickItemBtn = useCallback((key: React.Key, childKey?: React.Key, index: number = -1) => {
         setItemSelected({ key, childKey: childKey || '' });
         onClickMenu(childKey || key);
 
-        if (index && index > -1) {
+        if (index > -1) {
             const elements = document.querySelectorAll('.menu-overflow-item');
             const element = elements[index] as HTMLElement;
             if (element) {


### PR DESCRIPTION
### Hiện tượng
Tại Category Menu, nếu scroll đến `category tab` khác `Tất cả`. Sau đó nhấn vào dropdown tab của category và chọn `Tất cả` thì lúc này nó không scroll đến tab `Tất cả` trên `category menu`.
### Nguyên nhân
Vì `Tất cả` trên category menu nó có `index `là 0 nhưng nó kiểm tra nếu `index && index > -1` do đó nó dẫn đến nó không thể lấy được element của `Tất cả`.
### Giải pháp
Chỉ lấy điều kiện `index > -1`. Đồng thời cần sửa lại param `index` của hàm `onClickItemBtn` thành `index: number = -1`