### PR TITLE
Merge develop to master

### DIFF
--- a/app/(main)/free-patterns/[slug]/layout.tsx
+++ b/app/(main)/free-patterns/[slug]/layout.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { BookmarkModalProvider } from '@/app/context/BookmarkModalContext';
 import { ReactNode } from 'react';
 

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { BookmarkModalProvider } from '@/app/context/BookmarkModalContext';
 import { ReactNode } from 'react';
 

--- a/app/(main)/profile/layout.tsx
+++ b/app/(main)/profile/layout.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { BookmarkModalProvider } from '@/app/context/BookmarkModalContext';
 import { ReactNode } from 'react';
 

--- a/app/components/home/FreePatternsNode.tsx
+++ b/app/components/home/FreePatternsNode.tsx
@@ -10,6 +10,7 @@ import { ROUTE_PATH } from "@/app/lib/constant";
 import ReadMoreBtn from "../read-more";
 import { Pattern } from "@/app/lib/definitions";
 import { useRouter } from "next/navigation";
+import { BookmarkModalProvider } from "@/app/context/BookmarkModalContext";
 
 const FreePatternsNode = ({patterns}: {patterns: Pattern[]}) => {
 
@@ -19,34 +20,36 @@ const FreePatternsNode = ({patterns}: {patterns: Pattern[]}) => {
 	};
 	
 	return (
-		<div className='patterns'>
-			<HeaderPart
-				titleId='Home.FreePattern.title'
-				descriptionId='Home.FreePattern.description'
-				isShowDivider
-			/>
-			<Row gutter={[{ xs: 8, sm: 16, xl: 24 }, { xs: 12, sm: 16, xl: 24 }]}>
-				{
-					map(patterns, (pattern, index) =>
-						<Col key={`freepattern_${index}`} xs={12} sm={8} lg={6} >
-							<FreePatternCard
-								pattern={pattern}
-								onReadDetail={() => onViewPattern(pattern.id || '')}
-							/>
-						</Col>
-					)
-				}
-			</Row>
-			{patterns?.length > 0 ?
-				< div className='read-more'>
-					<ReadMoreBtn path={ROUTE_PATH.FREEPATTERNS} />
-				</div> :
-				<Empty
-					imageStyle={{ height: 80 }}
-					image={Empty.PRESENTED_IMAGE_SIMPLE}
+		<BookmarkModalProvider>
+			<div className='patterns'>
+				<HeaderPart
+					titleId='Home.FreePattern.title'
+					descriptionId='Home.FreePattern.description'
+					isShowDivider
 				/>
-			}
-		</div >
+				<Row gutter={[{ xs: 8, sm: 16, xl: 24 }, { xs: 12, sm: 16, xl: 24 }]}>
+					{
+						map(patterns, (pattern, index) =>
+							<Col key={`freepattern_${index}`} xs={12} sm={8} lg={6} >
+								<FreePatternCard
+									pattern={pattern}
+									onReadDetail={() => onViewPattern(pattern.id || '')}
+								/>
+							</Col>
+						)
+					}
+				</Row>
+				{patterns?.length > 0 ?
+					< div className='read-more'>
+						<ReadMoreBtn path={ROUTE_PATH.FREEPATTERNS} />
+					</div> :
+					<Empty
+						imageStyle={{ height: 80 }}
+						image={Empty.PRESENTED_IMAGE_SIMPLE}
+					/>
+				}
+			</div >
+		</BookmarkModalProvider>
 	)
 }
 


### PR DESCRIPTION
This pull request includes changes to multiple layout files and the `FreePatternsNode` component to add the `BookmarkModalProvider` and enable client-side rendering.

Client-side rendering:

* `app/(main)/free-patterns/[slug]/layout.tsx`: Added `'use client'` directive to enable client-side rendering. ([app/(main)/free-patterns/[slug]/layout.tsxR1-R2](diffhunk://#diff-37900bf0087fa9d289a82c2dc96515b3951904246466b41b4d8109ef3911530eR1-R2))
* [`app/(main)/layout.tsx`](diffhunk://#diff-5c551bd531dcf4bccf457ebf353b197db04402c2edde824234e500d2763c74acR1-R2): Added `'use client'` directive to enable client-side rendering.
* [`app/(main)/profile/layout.tsx`](diffhunk://#diff-2749817865e5ba92c678cc2db555040a24841c58e3258181ef8087b087180a77R1-R2): Added `'use client'` directive to enable client-side rendering.

Bookmark modal provider:

* [`app/components/home/FreePatternsNode.tsx`](diffhunk://#diff-fcbfab4df154e4d28813b29aeb4b8ad0eff305627737b528755bcff55dafa475R13): Imported `BookmarkModalProvider` and wrapped the component's return value with it to provide bookmark modal context. [[1]](diffhunk://#diff-fcbfab4df154e4d28813b29aeb4b8ad0eff305627737b528755bcff55dafa475R13) [[2]](diffhunk://#diff-fcbfab4df154e4d28813b29aeb4b8ad0eff305627737b528755bcff55dafa475R23) [[3]](diffhunk://#diff-fcbfab4df154e4d28813b29aeb4b8ad0eff305627737b528755bcff55dafa475R52)