### PR TITLE
Add user ID column with profile links in Users table

### DIFF
--- a/app/dashboard/users/Users.tsx
+++ b/app/dashboard/users/Users.tsx
@@ -9,6 +9,7 @@ import {useRouter} from 'next/navigation';
 import {ROUTE_PATH} from '@/app/lib/constant';
 import {sfLike, sfOr} from "spring-filter-query-builder";
 import {debounce} from '@/app/lib/utils';
+import Link from "next/link";
 
 const initialState: DataTableState = {
     loading: false,
@@ -70,8 +71,15 @@ const Users = () => {
 
     const columns = [
         {
+            title: 'Id',
+            dataIndex: 'id',
+            render: (value: string) => (
+                <Link href={`${ROUTE_PATH.PROFILE}/${value}`}>{value}</Link>
+            )
+        },
+        {
             title: 'Email',
-            dataIndex: 'email',
+            dataIndex: 'email'
         },
         {
             title: 'Role',


### PR DESCRIPTION
### Description
This pull request introduces an "Id" column in the Users table, linking each user ID to their profile page using `Next.js` `Link`. This improves navigation efficiency and aids in streamlined user management workflows.

### Checklist
- [x] Tested changes in different browsers
- [x] Updated relevant documentation
- [x] Verified that no existing functionality is broken