### PR TITLE
feat: implement change, forgot, and reset password UI

### DIFF
--- a/app/(auth)/forgot-password/ForgotPassword.tsx
+++ b/app/(auth)/forgot-password/ForgotPassword.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import React, { useState } from 'react';
+import { MailOutlined, LeftOutlined } from '@ant-design/icons';
+import { Button, Col, Flex, Form, Input, Row, Spin } from 'antd';
+import Link from 'next/link';
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+
+import logo from '@/public/logo.png';
+import { ROUTE_PATH, REGEX } from '@/app/lib/constant';
+import { passwordResetRequest } from '@/app/lib/service/registerService';
+import { notification } from '@/app/lib/notify';
+import '../../ui/components/login.scss';
+
+const ForgotPassword = () => {
+    const [form] = Form.useForm();
+    const t = useTranslations('ForgotPassword');
+    const [isLoading, setIsLoading] = useState(false);
+
+    const onFinish = async (values: { email: string }) => {
+        setIsLoading(true);
+        try {
+            const res = await passwordResetRequest(values.email);
+            if (res.status) {
+                notification.success({
+                    message: t('success_title'),
+                    description: t('success_description')
+                });
+                form.resetFields();
+            } else {
+                notification.error({
+                    message: t('error_title'),
+                    description: res.data?.message || t('error_description')
+                });
+            }
+        } catch (error: any) {
+            notification.error({
+                message: t('error_title'),
+                description: error?.message || t('error_description')
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <div className='auth-page login-page'>
+            <Flex justify='center' className='logo'>
+                <Link href={ROUTE_PATH.HOME}>
+                    <Image priority src={logo} alt='Tiệm len Tiểu Phương' width={150} height={150} />
+                </Link>
+            </Flex>
+            <Flex className="header-title" justify='center'>
+                <h3 className="title">{t('title')}</h3>
+            </Flex>
+            <Spin spinning={isLoading} tip="Loading...">
+                <Row>
+                    <Col xs={20} sm={18} md={10}>
+                        <Form
+                            form={form}
+                            name="forgot_password"
+                            className="login-form layout-wrap"
+                            onFinish={onFinish}
+                            disabled={isLoading}
+                        >
+                            <p className="description-text" style={{ marginBottom: 24, textAlign: 'center' }}>
+                                {t('instruction')}
+                            </p>
+                            <Form.Item
+                                name="email"
+                                rules={[
+                                    {
+                                        required: true,
+                                        message: t('error_msg_required_email')
+                                    },
+                                    {
+                                        pattern: new RegExp(REGEX.EMAIL),
+                                        message: t('error_msg_incorrect_email'),
+                                    },
+                                ]}
+                            >
+                                <Input
+                                    maxLength={100}
+                                    placeholder={t('input_email')}
+                                    prefix={<MailOutlined className="site-form-item-icon" />}
+                                />
+                            </Form.Item>
+                            
+                            <Form.Item className='actions'>
+                                <Row gutter={[10, 20]} align='middle'>
+                                    <Col xs={24}>
+                                        <Button
+                                            block
+                                            type="primary"
+                                            loading={isLoading}
+                                            htmlType="submit"
+                                            className="login-form-button btn-border"
+                                            disabled={isLoading}
+                                        >
+                                            {t('btn_submit')}
+                                        </Button>
+                                    </Col>
+                                    <Col xs={24} style={{ textAlign: 'center', marginTop: 12 }}>
+                                        <Link href={ROUTE_PATH.LOGIN} style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                                            <LeftOutlined style={{ fontSize: 12 }} /> {t('back_to_login')}
+                                        </Link>
+                                    </Col>
+                                </Row>
+                            </Form.Item>
+                        </Form>
+                    </Col>
+                </Row>
+            </Spin>
+        </div>
+    );
+};
+
+export default ForgotPassword;

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,34 @@
+import { ROUTE_PATH } from "@/app/lib/constant";
+import { getTranslations } from "next-intl/server";
+import { Metadata } from "next/types";
+import ForgotPassword from "./ForgotPassword";
+
+export async function generateMetadata(): Promise<Metadata> {
+	const t = await getTranslations("ForgotPassword");
+	return {
+		title: t("title"),
+		description: t("description"),
+		openGraph: {
+			title: t("title"),
+			description: t("description"),
+			url: `${process.env.NEXT_PUBLIC_URL}/forgot-password`,
+			type: 'website',
+			images: [   
+				{
+					url: `${process.env.NEXT_PUBLIC_URL}/opengraph-image.jpg`,
+					width: 1200,
+					height: 630,
+					alt: 'Forgot Password Tieu Phuong Crochet',
+				},
+			],
+		},
+	}
+}
+
+const ForgotPasswordPage = () => {
+    return (
+        <ForgotPassword />
+    )
+}
+
+export default ForgotPasswordPage;

--- a/app/(auth)/login/Login.tsx
+++ b/app/(auth)/login/Login.tsx
@@ -119,7 +119,7 @@ const Login = () => {
                                     <Checkbox>{t('remember_me')}</Checkbox>
                                 </Form.Item>
 
-                                <Link className="login-form-forgot" href="#">
+                                <Link className="login-form-forgot" href="/forgot-password">
                                     {t('forgot_password')}
                                 </Link>
                             </Form.Item>

--- a/app/(auth)/reset-password/ResetPassword.tsx
+++ b/app/(auth)/reset-password/ResetPassword.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import React, { useState } from 'react';
+import { LockOutlined, LeftOutlined } from '@ant-design/icons';
+import { Button, Col, Flex, Form, Input, Row, Spin } from 'antd';
+import Link from 'next/link';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+import logo from '@/public/logo.png';
+import { ROUTE_PATH, REGEX } from '@/app/lib/constant';
+import { resetPassword } from '@/app/lib/service/registerService';
+import { notification } from '@/app/lib/notify';
+import '../../ui/components/login.scss';
+
+interface ResetPasswordProps {
+    token: string;
+}
+
+const ResetPassword = ({ token }: ResetPasswordProps) => {
+    const [form] = Form.useForm();
+    const router = useRouter();
+    const t = useTranslations('ResetPassword');
+    const [isLoading, setIsLoading] = useState(false);
+
+    const onFinish = async (values: any) => {
+        if (!token) {
+            notification.error({
+                message: t('error_title'),
+                description: t('token_missing')
+            });
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            const res = await resetPassword(token, values.newPassword);
+            if (res.status) {
+                notification.success({
+                    message: t('success_title'),
+                    description: t('success_description')
+                });
+                setTimeout(() => {
+                    router.push(ROUTE_PATH.LOGIN);
+                }, 2000);
+            } else {
+                notification.error({
+                    message: t('error_title'),
+                    description: res.data?.message || t('error_description')
+                });
+            }
+        } catch (error: any) {
+            notification.error({
+                message: t('error_title'),
+                description: error?.message || t('error_description')
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <div className='auth-page login-page'>
+            <Flex justify='center' className='logo'>
+                <Link href={ROUTE_PATH.HOME}>
+                    <Image priority src={logo} alt='Tiệm len Tiểu Phương' width={150} height={150} />
+                </Link>
+            </Flex>
+            <Flex className="header-title" justify='center'>
+                <h3 className="title">{t('title')}</h3>
+            </Flex>
+            <Spin spinning={isLoading} tip="Loading...">
+                <Row>
+                    <Col xs={20} sm={18} md={10}>
+                        <Form
+                            form={form}
+                            name="reset_password"
+                            className="login-form layout-wrap"
+                            onFinish={onFinish}
+                            disabled={isLoading}
+                        >
+                            {!token && (
+                                <p className="error-text" style={{ color: 'red', textAlign: 'center', marginBottom: 24 }}>
+                                    {t('token_invalid_or_missing')}
+                                </p>
+                            )}
+                            <Form.Item
+                                name="newPassword"
+                                rules={[
+                                    {
+                                        required: true,
+                                        message: t('error_msg_required_password')
+                                    },
+                                    {
+                                        pattern: REGEX.PASSWORD,
+                                        message: t('password_pattern_msg')
+                                    }
+                                ]}
+                            >
+                                <Input.Password
+                                    placeholder={t('input_new_password')}
+                                    prefix={<LockOutlined className="site-form-item-icon" />}
+                                />
+                            </Form.Item>
+
+                            <Form.Item
+                                name="confirmPassword"
+                                dependencies={['newPassword']}
+                                rules={[
+                                    {
+                                        required: true,
+                                        message: t('error_msg_required_confirm_password')
+                                    },
+                                    ({ getFieldValue }) => ({
+                                        validator(_, value) {
+                                            if (!value || getFieldValue('newPassword') === value) {
+                                                return Promise.resolve();
+                                            }
+                                            return Promise.reject(new Error(t('passwords_do_not_match')));
+                                        },
+                                    }),
+                                ]}
+                            >
+                                <Input.Password
+                                    placeholder={t('input_confirm_password')}
+                                    prefix={<LockOutlined className="site-form-item-icon" />}
+                                />
+                            </Form.Item>
+                            
+                            <Form.Item className='actions'>
+                                <Row gutter={[10, 20]} align='middle'>
+                                    <Col xs={24}>
+                                        <Button
+                                            block
+                                            type="primary"
+                                            loading={isLoading}
+                                            htmlType="submit"
+                                            className="login-form-button btn-border"
+                                            disabled={isLoading || !token}
+                                        >
+                                            {t('btn_submit')}
+                                        </Button>
+                                    </Col>
+                                    <Col xs={24} style={{ textAlign: 'center', marginTop: 12 }}>
+                                        <Link href={ROUTE_PATH.LOGIN} style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                                            <LeftOutlined style={{ fontSize: 12 }} /> {t('back_to_login')}
+                                        </Link>
+                                    </Col>
+                                </Row>
+                            </Form.Item>
+                        </Form>
+                    </Col>
+                </Row>
+            </Spin>
+        </div>
+    );
+};
+
+export default ResetPassword;

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,39 @@
+import { getTranslations } from "next-intl/server";
+import { Metadata } from "next/types";
+import ResetPassword from "./ResetPassword";
+
+export async function generateMetadata(): Promise<Metadata> {
+	const t = await getTranslations("ResetPassword");
+	return {
+		title: t("title"),
+		description: t("description"),
+		openGraph: {
+			title: t("title"),
+			description: t("description"),
+			url: `${process.env.NEXT_PUBLIC_URL}/reset-password`,
+			type: 'website',
+			images: [   
+				{
+					url: `${process.env.NEXT_PUBLIC_URL}/opengraph-image.jpg`,
+					width: 1200,
+					height: 630,
+					alt: 'Reset Password Tieu Phuong Crochet',
+				},
+			],
+		},
+	}
+}
+
+interface ResetPasswordPageProps {
+  searchParams: {
+    token?: string;
+  };
+}
+
+const ResetPasswordPage = ({ searchParams }: ResetPasswordPageProps) => {
+    return (
+        <ResetPassword token={searchParams?.token || ''} />
+    )
+}
+
+export default ResetPasswordPage;

--- a/app/(main)/profile/Profile.tsx
+++ b/app/(main)/profile/Profile.tsx
@@ -22,6 +22,7 @@ import Collections from "@/app/components/profile/Collections";
 
 const FreePatterns = dynamic(() => import('../../components/profile/FreePatterns'), { ssr: false });
 const LikedPatterns = dynamic(() => import('../../components/profile/LikedPatterns'), { ssr: false });
+const ChangePassword = dynamic(() => import('../../components/profile/ChangePassword'), { ssr: false });
 
 interface ProfileDetailProps {
     params: {
@@ -88,6 +89,11 @@ const ProfileDetail = ({ params }: ProfileDetailProps) => {
                 key: 'info',
                 label: t('tabs.info'),
                 children: <UserInfo userData={userData} setUserData={setUserData} />,
+            },
+            {
+                key: 'change_password',
+                label: t('tabs.change_password'),
+                children: <ChangePassword />,
             },
         ] : defaultTabs;
     }, [isCreator, userId, t, userData]);

--- a/app/components/profile/ChangePassword.tsx
+++ b/app/components/profile/ChangePassword.tsx
@@ -1,0 +1,98 @@
+import { Form, Input, Button } from 'antd';
+import { useTranslations } from 'next-intl';
+import { changeUserPassword } from '@/app/lib/service/profileService';
+import { notification } from '@/app/lib/notify';
+import { REGEX } from '@/app/lib/constant';
+import { useState } from 'react';
+
+const ChangePassword = () => {
+    const t = useTranslations('Profile');
+    const [form] = Form.useForm();
+    const [loading, setLoading] = useState(false);
+
+    const onFinish = async (values: any) => {
+        setLoading(true);
+        try {
+            const res = await changeUserPassword({
+                oldPassword: values.oldPassword,
+                newPassword: values.newPassword
+            });
+
+            if (res.success) {
+                notification.success({
+                    message: t('change_password.success_msg')
+                });
+                form.resetFields();
+            } else {
+                notification.error({
+                    message: res.message || t('change_password.error_msg')
+                });
+            }
+        } catch (error: any) {
+            console.error('Error changing password:', error);
+            notification.error({
+                message: error?.response?.data?.message || t('change_password.error_msg')
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="user-info-tab">
+            <Form
+                form={form}
+                layout="vertical"
+                onFinish={onFinish}
+                style={{ maxWidth: 600 }}
+            >
+                <Form.Item
+                    name="oldPassword"
+                    label={t('change_password.old_password')}
+                    rules={[{ required: true, message: t('change_password.old_password_required') }]}
+                >
+                    <Input.Password />
+                </Form.Item>
+
+                <Form.Item
+                    name="newPassword"
+                    label={t('change_password.new_password')}
+                    rules={[
+                        { required: true, message: t('change_password.new_password_required') },
+                        {
+                            pattern: REGEX.PASSWORD,
+                            message: t('change_password.password_pattern_msg')
+                        }
+                    ]}
+                >
+                    <Input.Password />
+                </Form.Item>
+
+                <Form.Item
+                    name="confirmPassword"
+                    label={t('change_password.confirm_password')}
+                    dependencies={['newPassword']}
+                    rules={[
+                        { required: true, message: t('change_password.confirm_password_required') },
+                        ({ getFieldValue }) => ({
+                            validator(_, value) {
+                                if (!value || getFieldValue('newPassword') === value) {
+                                    return Promise.resolve();
+                                }
+                                return Promise.reject(new Error(t('change_password.passwords_do_not_match')));
+                            },
+                        }),
+                    ]}
+                >
+                    <Input.Password />
+                </Form.Item>
+
+                <Button className='btn-border' type="primary" htmlType="submit" loading={loading}>
+                    {t('change_password.submit')}
+                </Button>
+            </Form>
+        </div>
+    );
+};
+
+export default ChangePassword;

--- a/app/lib/constant.ts
+++ b/app/lib/constant.ts
@@ -223,6 +223,7 @@ export const API_ROUTES = {
   SIGNUP: '/api/v1/auth/signup', 
   LOGOUT: '/api/v1/auth/logout',
   RESET_PASSWORD: '/api/v1/auth/password-reset-request',
+  RESET_PASSWORD_SUBMIT: '/api/v1/auth/reset-password',
   CONFIRM: '/api/v1/auth/confirm',
   RESEND_VERIFICATION: '/api/v1/auth/resend-verification-email',
   REFRESH_TOKEN: '/api/v1/auth/refresh-token',

--- a/app/lib/constant.ts
+++ b/app/lib/constant.ts
@@ -230,6 +230,7 @@ export const API_ROUTES = {
   // User routes
   USERS: '/api/v1/users',
   USER_PROFILE: '/api/v1/user-profile',
+  USER_CHANGE_PASSWORD: '/api/v1/user-profile/change-password',
   USER_COLLECTIONS: '/api/v1/users/{userId}/collections',
   USER_FREE_PATTERNS: '/api/v1/users/{userId}/free-pattern',
   USER_LIKED_FREE_PATTERNS: '/api/v1/users/{userId}/liked-free-patterns',

--- a/app/lib/service/profileService.ts
+++ b/app/lib/service/profileService.ts
@@ -172,3 +172,13 @@ export async function loadUserInfo(id: string = '') {
         backgroundImageUrl: res.data.backgroundImageUrl
     };
 }
+
+export async function changeUserPassword(data: any) {
+    const res = await apiJwtService({
+        endpoint: API_ROUTES.USER_CHANGE_PASSWORD,
+        method: 'PUT',
+        data
+    });
+    return res;
+}
+

--- a/app/lib/service/registerService.ts
+++ b/app/lib/service/registerService.ts
@@ -19,3 +19,45 @@ export const registerService = async (data: User) => {
     }
   } catch (error: any) {}
 }
+
+export const passwordResetRequest = async (email: string) => {
+  try {
+    const url = new URL(API_ROUTES.RESET_PASSWORD, process.env.NEXT_PUBLIC_API_URL)
+    url.searchParams.append('email', email)
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+    })
+
+    const data = await response.json()
+    return {
+      status: response.ok,
+      data
+    }
+  } catch (error: any) {
+    return { status: false, data: null }
+  }
+}
+
+export const resetPassword = async (token: string, newPassword: string) => {
+  try {
+    const url = new URL(API_ROUTES.RESET_PASSWORD_SUBMIT, process.env.NEXT_PUBLIC_API_URL)
+    url.searchParams.append('passwordResetToken', token)
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ newPassword }),
+    })
+
+    const data = await response.json()
+    return {
+      status: response.ok,
+      data
+    }
+  } catch (error: any) {
+    return { status: false, data: null }
+  }
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -202,6 +202,36 @@
     "btn_google_login": "Login with Google",
     "text_Or": "Or"
   },
+  "ForgotPassword": {
+    "title": "Forgot Password",
+    "description": "Request a password reset link",
+    "instruction": "Enter your registered email address. We will send you a link to reset your password.",
+    "input_email": "Enter your email",
+    "error_msg_required_email": "Please enter your email",
+    "error_msg_incorrect_email": "Incorrect email format!",
+    "btn_submit": "Send Reset Link",
+    "back_to_login": "Back to Login",
+    "success_title": "Request Sent Successfully",
+    "success_description": "Please check your email for the password reset link.",
+    "error_title": "Request Failed",
+    "error_description": "Could not process password reset request. Please try again later."
+  },
+  "ResetPassword": {
+    "title": "Reset Password",
+    "description": "Enter your new password",
+    "token_missing": "Password reset token is missing. Please use the link in your email.",
+    "token_invalid_or_missing": "The password reset link is invalid or has expired.",
+    "input_new_password": "New password",
+    "input_confirm_password": "Confirm new password",
+    "error_msg_required_password": "Please enter your new password",
+    "error_msg_required_confirm_password": "Please confirm your new password",
+    "password_pattern_msg": "Password must be at least 8 characters long, and include uppercase, lowercase, digit, and a special character",
+    "passwords_do_not_match": "The new password and confirmation password do not match",
+    "btn_submit": "Update Password",
+    "back_to_login": "Back to Login",
+    "success_title": "Password Reset Successful",
+    "success_description": "Your password has been successfully updated. Redirecting to login page..."
+  },
   "Register": {
     "title": "Register account",
     "btn_sign_in": "Sign in!",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -271,7 +271,21 @@
       "collections": "Collections",
       "patterns": "Charts",
       "like": "Liked",
-      "info": "User info"
+      "info": "User info",
+      "change_password": "Change password"
+    },
+    "change_password": {
+      "old_password": "Old password",
+      "old_password_required": "Please enter your old password",
+      "new_password": "New password",
+      "new_password_required": "Please enter your new password",
+      "confirm_password": "Confirm new password",
+      "confirm_password_required": "Please confirm your new password",
+      "password_pattern_msg": "Password must be at least 8 characters long, and include uppercase, lowercase, digit, and a special character",
+      "passwords_do_not_match": "The new password and confirmation password do not match",
+      "submit": "Change password",
+      "success_msg": "Password changed successfully",
+      "error_msg": "Failed to change password"
     },
     "collections": {
       "empty": "No collections yet",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -271,7 +271,21 @@
       "collections": "Bộ sưu tập",
       "patterns": "Charts",
       "like": "Đã thích",
-      "info": "Thông tin cá nhân"
+      "info": "Thông tin cá nhân",
+      "change_password": "Đổi mật khẩu"
+    },
+    "change_password": {
+      "old_password": "Mật khẩu cũ",
+      "old_password_required": "Vui lòng nhập mật khẩu cũ",
+      "new_password": "Mật khẩu mới",
+      "new_password_required": "Vui lòng nhập mật khẩu mới",
+      "confirm_password": "Xác nhận mật khẩu mới",
+      "confirm_password_required": "Vui lòng xác nhận mật khẩu mới",
+      "password_pattern_msg": "Mật khẩu phải chứa ít nhất 8 ký tự, bao gồm chữ hoa, chữ thường, chữ số và ký tự đặc biệt",
+      "passwords_do_not_match": "Mật khẩu mới và xác nhận mật khẩu không khớp",
+      "submit": "Đổi mật khẩu",
+      "success_msg": "Đổi mật khẩu thành công",
+      "error_msg": "Đổi mật khẩu thất bại"
     },
     "collections": {
       "empty": "Chưa có bộ sưu tập nào",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -202,6 +202,36 @@
     "btn_google_login": "Đăng nhập với Google",
     "text_Or": "Hoặc"
   },
+  "ForgotPassword": {
+    "title": "Quên mật khẩu",
+    "description": "Yêu cầu liên kết đặt lại mật khẩu",
+    "instruction": "Nhập địa chỉ email đã đăng ký của bạn. Chúng tôi sẽ gửi một liên kết để đặt lại mật khẩu của bạn.",
+    "input_email": "Nhập email của bạn",
+    "error_msg_required_email": "Vui lòng nhập email",
+    "error_msg_incorrect_email": "Định dạng email không chính xác!",
+    "btn_submit": "Gửi yêu cầu",
+    "back_to_login": "Quay lại Đăng nhập",
+    "success_title": "Đã gửi yêu cầu thành công",
+    "success_description": "Vui lòng kiểm tra email của bạn để nhận liên kết đặt lại mật khẩu.",
+    "error_title": "Gửi yêu cầu thất bại",
+    "error_description": "Không thể xử lý yêu cầu đặt lại mật khẩu. Vui lòng thử lại sau."
+  },
+  "ResetPassword": {
+    "title": "Đặt lại mật khẩu",
+    "description": "Nhập mật khẩu mới của bạn",
+    "token_missing": "Token đặt lại mật khẩu bị thiếu. Vui lòng sử dụng liên kết trong email của bạn.",
+    "token_invalid_or_missing": "Liên kết đặt lại mật khẩu không hợp lệ hoặc đã hết hạn.",
+    "input_new_password": "Mật khẩu mới",
+    "input_confirm_password": "Xác nhận mật khẩu mới",
+    "error_msg_required_password": "Vui lòng nhập mật khẩu mới",
+    "error_msg_required_confirm_password": "Vui lòng xác nhận mật khẩu mới",
+    "password_pattern_msg": "Mật khẩu phải chứa ít nhất 8 ký tự, bao gồm chữ hoa, chữ thường, chữ số và ký tự đặc biệt",
+    "passwords_do_not_match": "Mật khẩu mới và xác nhận mật khẩu không khớp",
+    "btn_submit": "Cập nhật mật khẩu",
+    "back_to_login": "Quay lại Đăng nhập",
+    "success_title": "Đổi mật khẩu thành công",
+    "success_description": "Mật khẩu của bạn đã được cập nhật thành công. Đang chuyển hướng về trang đăng nhập..."
+  },
   "Register": {
     "title": "Đăng ký",
     "account_exist": "Đã có tài khoản?",


### PR DESCRIPTION
This PR adds the Change Password tab in user profile, Forgot Password page to request email links, and Reset Password page to submit new passwords via email tokens, with comprehensive form validation and localization support.